### PR TITLE
fix for linux app config folder

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -43,7 +43,7 @@ async function getCandidatePaths() {
         "Local Storage",
         "leveldb"
       ),
-      { strict: false, silent: true },
+      { strict: false, silent: true, dot: true },
       (err, matches) => {
         if (err) {
           reject(err);
@@ -61,6 +61,8 @@ function getLocalStoragePathPrefix() {
       return "%LOCALAPPDATA%";
     case "darwin":
       return path.resolve(os.homedir(), "Library", "Application Support");
+    case "linux":
+      return path.resolve(os.homedir(), ".config");
     default:
       return os.homedir();
   }


### PR DESCRIPTION
- app data is in .config on linux, at least for chrome, brave...
- The stock glob does not match dot in the pattern, which caused the default in the switch to skip my $HOME/.config folder

```
    interface IOptions extends minimatch.IOptions {
        ...
        dot?: boolean | undefined;
```

> Allow patterns to match filenames starting with a period, even if the pattern does not explicitly have a period in that spot.
> 
> Note that by default, 'a/**' + '/b' will not match a/.d/b, unless dot is set.